### PR TITLE
Fix bug where the foreground property did not affect the appearance correctly

### DIFF
--- a/src/CurrencyTextBoxControl/CurrencyTextBox.cs
+++ b/src/CurrencyTextBoxControl/CurrencyTextBox.cs
@@ -66,12 +66,11 @@ namespace CurrencyTextBoxControl
         private static void NumberPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
         {
             CurrencyTextBox ctb = d as CurrencyTextBox;
+            if (ctb == null)
+                return;
 
-            //Color update
-            if (ctb.Number < 0)
-                ctb.Foreground = Brushes.Red;
-            else
-                ctb.Foreground = Brushes.Black;
+            //Update IsNegative
+            ctb.SetValue(IsNegativeProperty, ctb.Number < 0);
 
             //Launch event
             if (ctb.NumberChanged != null)
@@ -82,6 +81,14 @@ namespace CurrencyTextBoxControl
         {
             get { return (decimal)GetValue(NumberProperty); }
             set { SetValue(NumberProperty, value); }
+        }
+
+        public static readonly DependencyProperty IsNegativeProperty =
+            DependencyProperty.Register("IsNegative", typeof(bool), typeof(CurrencyTextBox), new PropertyMetadata(false));
+
+        public bool IsNegative
+        {
+            get { return (bool) GetValue(IsNegativeProperty); }
         }
         
         public bool IsCalculPanelMode

--- a/src/CurrencyTextBoxControl/Themes/Generic.xaml
+++ b/src/CurrencyTextBoxControl/Themes/Generic.xaml
@@ -1,11 +1,16 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:local="clr-namespace:CurrencyTextBoxControl"                    
-                    xmlns:themes="clr-namespace:Microsoft.Windows.Themes;assembly=PresentationFramework.Aero">
+                    xmlns:local="clr-namespace:CurrencyTextBoxControl">
 
-    <!--New Light Style-->
-    <Style TargetType="local:CurrencyTextBox" BasedOn="{StaticResource {x:Type TextBox}}">
+    <!--  New Light Style  -->
+    <Style BasedOn="{StaticResource {x:Type TextBox}}"
+           TargetType="local:CurrencyTextBox">
         <Setter Property="TextAlignment" Value="Right" />
+        <Style.Triggers>
+            <Trigger Property="IsNegative" Value="True">
+                <Setter Property="Foreground" Value="Red" />
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <!--<Style TargetType="{x:Type local:CurrencyTextBox}">


### PR DESCRIPTION
I was trying to use your nuget package and ran into an issue when trying to style the control. The foreground property would not pretain it's set brush. I found out that it was statically set to Brush.Black and changed it so that it now is changed by a trigger. Now the foreground can be changed via styles.